### PR TITLE
fix:module field in pkg and update example

### DIFF
--- a/example/src/main.js
+++ b/example/src/main.js
@@ -1,9 +1,11 @@
 import Vue from 'vue'
 import VueCompositionAPI, { createApp } from '@vue/composition-api'
+import VueI18n from "vue-i18n"
 import { createI18n } from 'vue-i18n-composable'
 import App from './App.vue'
 
 Vue.use(VueCompositionAPI)
+Vue.use(VueI18n)
 
 const i18n = createI18n({
   locale: 'ja',

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
       "secretlint"
     ]
   },
-  "main": "dist/index.js",
+  "type": "module",
+  "main": "dist/index.cjs",
   "module": "dist/index.js",
   "peerDependencies": {
     "@vue/composition-api": ">= 1.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     ]
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/index.js",
   "peerDependencies": {
     "@vue/composition-api": ">= 1.0.0-beta.1",
     "vue": ">=2.5 <3",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "yorkie": "^2.0.0"
   },
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/index.mjs"
+    "require": "./dist/index.cjs",
+    "import": "./dist/index.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
hello, @antfu @kazupon  

I Struggling with the issue #14 #10  when i run example in this project.
finally,i think maybe the problem is the lastest version 0.2.2 use incorrect module field `dist/index.mjs` in package.json 

https://github.com/webpack/webpack/issues/7482

when we use `dist/index.mjs`  `.mjs` tries to be as compatible as possible to node.js
so ⬇️  
```js
// dist/index.mjs
import VueCompositionApi from "@vue/composition-api" // this import incorrect  commonjs file
```

```js
// dist/index.mjs
import { computed, getCurrentInstance } from "@vue/composition-api";
// node_modules/@vue/composition-api/index.js ❌
```

![BEA10BB8-A09D-4037-8011-269B80680497](https://user-images.githubusercontent.com/40595135/144216195-381db1ac-3401-46d8-9a53-178c8057e1ef.png)

when we use `dist/index.js`
```js
// dist/index.js
var _compositionapi = require('@vue/composition-api');
// node_modules/@vue/composition-api/dist/vue-composition-api.mjs 🌈
```

![46EAACB9-F331-427E-B14B-0E3B7A59E039](https://user-images.githubusercontent.com/40595135/144216220-f45d6e58-e48b-49d9-99ca-c4fc71f8d405.png)


finally

so i modify something in package.json follow this link https://tsup.egoist.sh/#bundle-formats

![image](https://user-images.githubusercontent.com/40595135/156350370-80ead3f1-060b-40f8-b3d9-4bacde9f2a5f.png)

is my understanding correct, maybe I'm missing something?