### PR TITLE
fix:can't access property _t, i18n is undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export function useI18n(): Composer {
   const vm =
     instance?.proxy ||
     (instance as unknown as InstanceType<VueConstructor>) ||
-    new Vue({})
+    new Vue({i18n})
 
   const locale = computed({
     get() {


### PR DESCRIPTION
This error occurred after creating a new Vue instance.
solved by passing the i18n instance to the new instance.

